### PR TITLE
Reload leaderboard component on file parse (get new data)

### DIFF
--- a/source/battle-board/battle-board/app/competition/[competition]/page.tsx
+++ b/source/battle-board/battle-board/app/competition/[competition]/page.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from 'react';
 import Image from 'next/image';
 import PlayerGrid from '@/components/playerGrid/PlayerGrid';
-import CompetitonModeWrapper from '@/components/competition/CompetitionModeWrapper';
 import fetchCompetitionData from '@/lib/leaderboard/fetchCompetitionData';
 import fetchGameName from '@/lib/leaderboard/fetchGameName';
 import fetchClassicLeaderBoard from '@/lib/leaderboard/fetchClassicLeaderBoard';
@@ -25,7 +24,7 @@ type CompetitionPageProps = Promise<{ competition: string }>;
 // Main Page Component
 const CompetitionPage = async (props: { params: CompetitionPageProps }) => {
   const { competitionData, gameName, leaderboard, competitionUsers } = await getCompetitionData((await props.params).competition);
-
+  
   return (
     <div className="w-full h-full flex flex-col gap-4 items-center">
       <div className="w-full flex text-slate-50 text-3xl flex-row items-center gap-4 px-10 py-0">
@@ -81,8 +80,7 @@ const CompetitionPage = async (props: { params: CompetitionPageProps }) => {
         </div>
       </Suspense>
       {/* Leaderboard component - contains edit and upload buttons to avoid excessive state inheritance (pls om ni kommer på bättre sätt help) */}
-      <LeaderboardComponent competitionId={competitionData.id} creatorName={competitionData.creator_name} initialLeaderboard={leaderboard} userNames={competitionUsers} />
-      <CompetitonModeWrapper mode={competitionData.competition_type} competitionId={competitionData.id} />
+      <LeaderboardComponent competitionId={competitionData.id} competitionData={competitionData} creatorName={competitionData.creator_name} initialLeaderboard={leaderboard} userNames={competitionUsers} />
     </div>
   );
 }

--- a/source/battle-board/battle-board/components/competition/CompetitionModeWrapper.tsx
+++ b/source/battle-board/battle-board/components/competition/CompetitionModeWrapper.tsx
@@ -1,14 +1,18 @@
-import * as React from 'react';
+import { Fragment } from 'react';
 import { Typography } from '@mui/material';
 import ClassicMode from '@/components/competitionModes/classicMode/ClassicMode';
 
 interface CompetitionModeWrapperProps {
     mode: number;
     competitionId: string;
+    reloadTrigger: number;
 }
 
-const CompetitonModeWrapper: React.FC<CompetitionModeWrapperProps> = ({ mode, competitionId }) => {
+const CompetitonModeWrapper: React.FC<CompetitionModeWrapperProps> = ({ mode, competitionId, reloadTrigger }) => {
     const renderContent = () => {
+
+        console.log("Loading competition mode:", mode);
+
         switch (mode) {
             case 1:
                 return <ClassicMode competitionId={competitionId} />;
@@ -33,7 +37,13 @@ const CompetitonModeWrapper: React.FC<CompetitionModeWrapperProps> = ({ mode, co
         }
     };
 
-    return renderContent();
+    return ( // Reload component when reloadTrigger changes
+        <Fragment key={reloadTrigger}> 
+            {renderContent()}
+        </Fragment>
+    );
+
+    //return renderContent();
 };
 
 export default CompetitonModeWrapper;

--- a/source/battle-board/battle-board/components/competition/LeaderboardComponent.tsx
+++ b/source/battle-board/battle-board/components/competition/LeaderboardComponent.tsx
@@ -1,32 +1,33 @@
 "use client";
 
-import { Suspense, useState, useEffect } from "react";
+import { Suspense, useState } from "react";
 import EditCompetitionButton from "@/components/competition/EditCompetitionButton";
 import FileUploadAndParseComponent from "@/components/competition/FileUploadAndParseButton";
 import { Leaderboard } from "@/models/leaderboard";
+import CompetitionData from "@/models/interfaces/CompetitionData";
+import CompetitonModeWrapper from '@/components/competition/CompetitionModeWrapper';
 
 const LeaderboardComponent = ({
   competitionId,
+  competitionData,
   creatorName,
   initialLeaderboard,
   userNames,
 }: {
   competitionId: string;
+  competitionData: CompetitionData;
   creatorName: string;
   initialLeaderboard: Leaderboard | null;
   userNames: string[] | null;
 }) => {
-  const [leaderboardData, setLeaderboardData] = useState<Leaderboard | null>(
-    null
-  );
+  
 
-  useEffect(() => {
-    setLeaderboardData(initialLeaderboard);
-  }, [initialLeaderboard]);
+  const [reload, setReload] = useState(0);
 
-  const handleCompetitionDataParsed = (data: Leaderboard) => {
-    setLeaderboardData(data);
-  };
+  const triggerReload = () => {
+    console.log("triggering reload");
+    setReload((prev) => prev + 1);
+  }
 
   if (userNames === null) {
     return <p>silli :P</p>;
@@ -37,11 +38,15 @@ const LeaderboardComponent = ({
       epic leaderboard
       <EditCompetitionButton competitionCreator={creatorName} />
       <FileUploadAndParseComponent
-        prevLeaderboard={leaderboardData}
+        prevLeaderboard={initialLeaderboard}
         userNames={userNames}
-        handleCompetitionDataParsed={handleCompetitionDataParsed}
+        handleCompetitionDataParsed={triggerReload}
         competitionId={competitionId}
       />
+
+      <CompetitonModeWrapper mode={competitionData.competition_type} competitionId={competitionId} reloadTrigger={reload} />
+
+
     </Suspense>
   );
 };

--- a/source/battle-board/battle-board/components/competitionModes/classicMode/ClassicMode.tsx
+++ b/source/battle-board/battle-board/components/competitionModes/classicMode/ClassicMode.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React, { useState, useEffect } from "react";
 import {
   Box,
   TableRow,
@@ -7,29 +7,65 @@ import {
   TableCell,
   TableBody,
   Table,
-  Typography
-} from '@mui/material'
+  Typography,
+} from "@mui/material";
 
-import fetchClassicLeaderBoard from '@/lib/leaderboard/fetchClassicLeaderBoard'
+import { Leaderboard } from "@/models/leaderboard";
 
-interface ClassidModeProps {
-  competitionId: string
+interface ClassicModeProps {
+  competitionId: string;
 }
 
-const ClassicMode: React.FC<ClassidModeProps> = async ({ competitionId }) => {
+const fetchClassicLeaderBoardDodge = async (
+  competitionId: string
+): Promise<Leaderboard | null> => {
+  //Jag är för dålig på react, vet ej hur man fetchar denna server-side + trigga reload
+  const response = await fetch(
+    `/api/competitions/leaderboard?competitionId=${competitionId}`
+  );
+  if (!response.ok) return null;
+  return response.json();
+};
 
-  const leaderboardData = await fetchClassicLeaderBoard(competitionId);
+const ClassicMode: React.FC<ClassicModeProps> = ({ competitionId }) => {
+  const [leaderboardData, setLeaderboardData] = useState<Leaderboard | null>(
+    null
+  );
+  const [loading, setLoading] = useState(true);
 
-  const rows = leaderboardData?.leaderboard_entries || [];
+  useEffect(() => {
+    const fetchLeaderboard = async () => {
+      setLoading(true);
+      try {
+        const data = await fetchClassicLeaderBoardDodge(competitionId);
+        setLeaderboardData(data);
+      } catch (error) {
+        console.error("Error fetching leaderboard data:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
 
-  const columns = leaderboardData?.column_names ? Object.keys(rows[0]) : []
+    fetchLeaderboard();
+  }, [competitionId]);
+
+  if (loading) {
+    return <Typography>Loading leaderboard...</Typography>;
+  }
+
+  if (!leaderboardData || !leaderboardData.leaderboard_entries.length) {
+    return <Typography>No leaderboard data available.</Typography>;
+  }
+
+  const rows = leaderboardData.leaderboard_entries;
+  const columns = leaderboardData.column_names;
 
   return (
-    <Box style={{ width: '60vw', margin: '0 0 100px 0' }}>
-      <TableContainer >
+    <Box style={{ width: "60vw", margin: "0 0 100px 0" }}>
+      <TableContainer>
         <Table sx={{ minWidth: 650 }} aria-label="dynamic table">
           <TableHead>
-            <TableRow >
+            <TableRow>
               {columns.map((column) => (
                 <TableCell key={column}>
                   <Typography className="h3">{column}</Typography>
@@ -37,17 +73,23 @@ const ClassicMode: React.FC<ClassidModeProps> = async ({ competitionId }) => {
               ))}
             </TableRow>
           </TableHead>
-          <TableBody >
+          <TableBody>
             {rows.map((row, rowIndex) => (
               <TableRow
                 key={rowIndex}
                 sx={{
-                  backgroundColor: rowIndex % 2 === 0 ? 'var(--purple-light)' : 'var(--purple-lighter)',
-                  '&:last-child td, &:last-child th': { border: 0 },
+                  backgroundColor:
+                    rowIndex % 2 === 0
+                      ? "var(--purple-light)"
+                      : "var(--purple-lighter)",
+                  "&:last-child td, &:last-child th": { border: 0 },
                 }}
               >
                 {columns.map((column) => (
-                  <TableCell key={column} sx={{ color: 'white', border: 'none' }}>
+                  <TableCell
+                    key={column}
+                    sx={{ color: "white", border: "none" }}
+                  >
                     <Typography className="breadText">{row[column]}</Typography>
                   </TableCell>
                 ))}
@@ -57,7 +99,7 @@ const ClassicMode: React.FC<ClassidModeProps> = async ({ competitionId }) => {
         </Table>
       </TableContainer>
     </Box>
-  )
-}
+  );
+};
 
 export default ClassicMode;


### PR DESCRIPTION
Reloads the LeaderboardComponent when a file has been parsed, which fetches and displays the new data. Unfortunately, some fetching had to be moved client side (I think) due to the reload depending on passing state. Pls help med att komma på bättre sätt.

Fixed some bugs in the parsing logic, causing errors on valid inputs, and success on invalid inputs.

Reset file name input after parsing, so that the same file (but modified) can be uploaded again. 