### PR TITLE
Extend bot functionality

### DIFF
--- a/source/BattleBot/BattleBot.py
+++ b/source/BattleBot/BattleBot.py
@@ -1,7 +1,10 @@
 import discord
 from discord.ext import commands
+from discord import Game
 from dotenv import load_dotenv
 from os import getenv
+
+from asyncio import sleep
 
 import requests
 import logging
@@ -16,13 +19,24 @@ bot = commands.Bot(command_prefix="!", intents=intents)
 # state_url_obj =
 # https://discord.com/oauth2/authorize?client_id=1308029231342555136&permissions=18136036801537&integration_type=0&scope=bot
 
+POLL_COMPETITIONS = False
+competitions_printed: list[str] = []
+
 
 @bot.event
 async def on_ready():
     try:
         synced = await bot.tree.sync()  # Sync all slash commands
+
+        activity = Game(name="BattleBoard")
+        await bot.change_presence(activity=activity)
+
         print(f"Synced {len(synced)} commands successfully!")
         print(f"API URL: {getenv('API_URL')}")
+
+        if POLL_COMPETITIONS:
+            print("Polling of community competitions enabled!")
+            bot.loop.create_task(poll_community_competitions())
 
     except Exception as e:
         print(f"Error syncing commands: {e}")
@@ -117,6 +131,95 @@ async def on_guild_remove(guild: discord.Guild):
         return
     
     print(f"Deleted community: {guild.name}")
+
+@bot.event
+async def on_member_join(member: discord.Member):
+    print(f"Member joined: {member.name}")
+
+    if member.id == bot.user.id:
+        print(f"Skipping bot user: {member.name}")
+        return
+
+    print(f"Adding member: {member.name} to community: {member.guild.name}")
+
+    member_data = {"user_name": member.name}
+
+    try:
+
+        res = requests.post(
+            getenv("API_URL") + f"/communities/{str(member.guild.id)}/users",
+            json=member_data,
+        )
+
+    except Exception as e:
+        print(f"Error adding member: {e}")
+        return
+
+    if res.status_code != 201:
+        print(f"Failed to add member: {res}")
+        return
+
+    print(f"Added member: {member.name} to community: {member.guild.name}")
+
+@bot.event
+async def on_member_remove(member: discord.Member):
+    print(f"Member left: {member.name}")
+
+    try:
+        res = requests.delete(getenv("API_URL") + f"/communities/{member.guild.id}/{member.name}")
+
+    except Exception as e:
+        print(f"Error deleting member: {e}")
+        return
+
+    if res.status_code != 200:
+        print(f"Failed to delete member: {res}")
+        return
+    
+    print(f"Deleted member: {member.name}")
+
+
+async def poll_community_competitions():
+    await bot.wait_until_ready()
+
+    while not bot.is_closed(): #loop while bot online
+        print("Polling competitions for all communities...")
+
+        for guild in bot.guilds:
+            res = requests.get(getenv("API_URL") + f"/communities/{str(guild.id)}/competitions")
+
+            if res.status_code != 200:
+                print(f"No competitions for community: {guild.name}")
+                continue
+
+            guild_competition_ids: list[str] = res.json()
+            print(guild_competition_ids)
+            guild_competitions = []
+
+            for competition_id in guild_competition_ids:
+                competition = requests.get(getenv("API_URL") + f"/competitions/{competition_id}")
+                guild_competitions.append(competition.json())
+
+            if len(guild_competitions) == 0:
+                print(f"No competitions found for community: {guild.name}")
+                continue
+
+            for competition in guild_competitions:
+                if competition["id"] in competitions_printed:
+                    continue
+
+                is_running = competition["is_running"]
+
+                if is_running:
+                    channel = guild.text_channels[0]
+                    competitions_printed.append(competition["id"])
+                    await channel.send(f"Competition: {competition['name']} has started!")
+
+        print("Finished polling competitions for all communities.")
+
+        await sleep(300)  # Poll every 5 minutes
+
+
 
 
 @bot.tree.command(name="test", description="skibidi toilet")

--- a/source/HermitStore/Program.cs
+++ b/source/HermitStore/Program.cs
@@ -187,6 +187,23 @@ app.MapGet("/communities/{id}/users", async (HermitDbContext dbContext, string i
     return Results.Ok(users);
 });
 
+app.MapDelete("/communities/{id}/{user_name}", async (HermitDbContext dbContext, string id, string user_name) =>
+{
+    var userCommunity = await dbContext
+        .user_community.Where(x => x.community_id.Equals(id) && x.user_name.Equals(user_name))
+        .FirstOrDefaultAsync();
+
+    if (userCommunity == null)
+    {
+        return Results.NotFound();
+    }
+
+    dbContext.user_community.Remove(userCommunity);
+    await dbContext.SaveChangesAsync();
+
+    return Results.Ok();
+});
+
 app.MapGet(
         "/competitions/public",
         async (HermitDbContext dbContext) =>


### PR DESCRIPTION
This PR chiefly adds functionality to the bot to make a user join a community when they join a discord server (after initial community creation where all members are imported), and also to handle the reverse case where a user leaves a server.

The status of the bot has also been updated to say _BattleBoard_. Server specific statuses are not possible since bots can only have a global status.

An experimental feature to poll each community for competitions every five minutes, and post a message to the main channel if a competition is running (that hasn't been "posted" since the bot started) has also been added. It is currently disabled, but can be enabled by changing the POLL_COMPETITIONS literal.  